### PR TITLE
Update GitHub Actions to Node 24 compatible versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Java 17 for AGP
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: 17

--- a/.github/workflows/check-badges.yml
+++ b/.github/workflows/check-badges.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Check badges in README.md
       run: ./scripts/check-badges.bash "README.md"


### PR DESCRIPTION
## Summary
- GitHub is deprecating Node 20 on Actions runners (EOL April 2026, removal Fall 2026)
- Updated all actions to their latest major versions with Node 24 runtime support
- actions/checkout v4 → v6
- actions/setup-java v4 → v5

## Test plan
- [ ] CI workflows pass on this PR branch