### PR TITLE
Release 26.6.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,3 +25,7 @@ jobs:
           fastlane-env: "release"
           ruby-version: "3.3"
           bundler-version: "2.4.22"
+          # Pin fastlane >= 2.236.0, which adds multi_json as a direct dep.
+          # The action's default (2.213.0) crashes with
+          # "multi_json is not part of the bundle" on load.
+          fastlane-version: "2.236.1"

--- a/README.md
+++ b/README.md
@@ -70,25 +70,27 @@ To use Aspose Barcode Cloud for Android you need to register an account with [As
 
 ## Getting Started
 
-- Open project in Android Studio
+- Open project in Android Studio.
 
-- Go to file *app/src/main/java/com/example/asposebarcodecloud/MainActivity.kt* and set *clientId* and *clientSecret* to apropriate values from <https://dashboard.aspose.cloud/applications>
+- Go to `app/src/main/java/com/aspose/barcode/cloud/demo_app/MainActivity.kt` and set your `clientId` and `clientSecret` from <https://dashboard.aspose.cloud/applications>.
 
-- Build project and run application on connected device or emulator.
+- Build the project and run the app on a connected device or emulator.
 
-## Generate Code128 BbarCode in Android using Java
+## Generate QR Barcode in Android using Kotlin
 
-```java
-    // Get your ClientId and ClientSecret from https://dashboard.aspose.cloud (free registration required).
-    ApiClient client = new ApiClient("MY_CLIENT_ID", "MY_CLIENT_SECRET");
+```kotlin
+val client = ApiClient("MY_CLIENT_ID", "MY_CLIENT_SECRET")
+val generateApi = GenerateApi(client)
 
-    BarcodeApi api = new BarcodeApi(client);
+val request = GenerateRequestWrapper(EncodeBarcodeType.QR, "text example")
+request.imageFormat = BarcodeImageFormat.PNG
+request.qrEncodeMode = QREncodeMode.AUTO
+request.qrErrorLevel = QRErrorLevel.LEVEL_M
+request.qrVersion = QRVersion.AUTO
+request.qrAspectRatio = 0.75f
 
-    String type = "code128";
-    String text = "text example";
-
-    File result = api.getBarcodeGenerate(type, text);
-    System.out.println(result);
+val result = generateApi.generate(request)
+println(result?.absolutePath)
 ```
 
 ## Licensing

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -38,7 +38,7 @@ dependencies {
     implementation 'androidx.core:core-ktx:1.18.0'
     implementation 'androidx.appcompat:appcompat:1.7.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.2.1'
-    implementation 'com.aspose:aspose-barcode-cloud:26.5.0'
+    implementation 'com.aspose:aspose-barcode-cloud:26.6.0'
     implementation 'com.google.android.material:material:1.13.0'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.3.0'

--- a/app/src/main/java/com/aspose/barcode/cloud/demo_app/MainActivity.kt
+++ b/app/src/main/java/com/aspose/barcode/cloud/demo_app/MainActivity.kt
@@ -54,6 +54,9 @@ import com.aspose.barcode.cloud.api.GenerateApi
 import com.aspose.barcode.cloud.api.ScanApi
 import com.aspose.barcode.cloud.model.BarcodeImageFormat
 import com.aspose.barcode.cloud.model.EncodeBarcodeType
+import com.aspose.barcode.cloud.model.QREncodeMode
+import com.aspose.barcode.cloud.model.QRErrorLevel
+import com.aspose.barcode.cloud.model.QRVersion
 import com.aspose.barcode.cloud.requests.GenerateRequestWrapper
 import com.aspose.barcode.cloud.requests.ScanMultipartRequestWrapper
 import com.google.android.material.snackbar.Snackbar
@@ -254,6 +257,13 @@ class MainActivity : AppCompatActivity() {
         genRequest.imageFormat = BarcodeImageFormat.PNG
         genRequest.imageHeight = barcodeImgView.measuredHeight.toFloat()
         genRequest.imageWidth = barcodeImgView.measuredWidth.toFloat()
+
+        if (type == EncodeBarcodeType.QR) {
+            genRequest.qrEncodeMode = QREncodeMode.AUTO
+            genRequest.qrErrorLevel = QRErrorLevel.LEVEL_M
+            genRequest.qrVersion = QRVersion.AUTO
+            genRequest.qrAspectRatio = 0.75f
+        }
 
         Thread {
             try {

--- a/app/src/main/java/com/aspose/barcode/cloud/demo_app/MainActivity.kt
+++ b/app/src/main/java/com/aspose/barcode/cloud/demo_app/MainActivity.kt
@@ -53,10 +53,12 @@ import com.aspose.barcode.cloud.ApiException
 import com.aspose.barcode.cloud.api.GenerateApi
 import com.aspose.barcode.cloud.api.ScanApi
 import com.aspose.barcode.cloud.model.BarcodeImageFormat
+import com.aspose.barcode.cloud.model.BarcodeImageParams
 import com.aspose.barcode.cloud.model.EncodeBarcodeType
 import com.aspose.barcode.cloud.model.QREncodeMode
 import com.aspose.barcode.cloud.model.QRErrorLevel
 import com.aspose.barcode.cloud.model.QRVersion
+import com.aspose.barcode.cloud.model.QrParams
 import com.aspose.barcode.cloud.requests.GenerateRequestWrapper
 import com.aspose.barcode.cloud.requests.ScanMultipartRequestWrapper
 import com.google.android.material.snackbar.Snackbar
@@ -254,15 +256,19 @@ class MainActivity : AppCompatActivity() {
         val type = EncodeBarcodeType.fromValue(barcodeTypeSpinner.selectedItem.toString())
 
         val genRequest = GenerateRequestWrapper(type, barcodeTextEdit.text.toString())
-        genRequest.imageFormat = BarcodeImageFormat.PNG
-        genRequest.imageHeight = barcodeImgView.measuredHeight.toFloat()
-        genRequest.imageWidth = barcodeImgView.measuredWidth.toFloat()
+        genRequest.barcodeImageParams = BarcodeImageParams().apply {
+            imageFormat = BarcodeImageFormat.PNG
+            imageHeight = barcodeImgView.measuredHeight.toFloat()
+            imageWidth = barcodeImgView.measuredWidth.toFloat()
+        }
 
         if (type == EncodeBarcodeType.QR) {
-            genRequest.qrEncodeMode = QREncodeMode.AUTO
-            genRequest.qrErrorLevel = QRErrorLevel.LEVEL_M
-            genRequest.qrVersion = QRVersion.AUTO
-            genRequest.qrAspectRatio = 0.75f
+            genRequest.qrParams = QrParams().apply {
+                qrEncodeMode = QREncodeMode.AUTO
+                qrErrorLevel = QRErrorLevel.LEVEL_M
+                qrVersion = QRVersion.AUTO
+                qrAspectRatio = 0.75f
+            }
         }
 
         Thread {


### PR DESCRIPTION
## Summary
- update Android demo and README for the June API 26.6 SDK release
- bump the Android sample dependency to `com.aspose:aspose-barcode-cloud:26.6.0`
- restore QR generation parameter usage in the demo app

## Validation
- Android app compiled locally after installing the local 26.6 Java SDK into Maven cache

No deployment is included in this PR.